### PR TITLE
Move configuration out of Blueprint

### DIFF
--- a/fourstoryFlask/__init__.py
+++ b/fourstoryFlask/__init__.py
@@ -1,14 +1,19 @@
+from dotenv import load_dotenv
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 import os
 
 db = SQLAlchemy()
 
+load_dotenv()
+
 def create_app():
 
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///fourstory.db'
     app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')
+    app.config['FOURSQUARE_CLIENT_ID'] = os.getenv('FOURSQUARE_CLIENT_ID')
+    app.config['FOURSQUARE_CLIENT_SECRET'] = os.getenv('FOURSQUARE_CLIENT_SECRET')
     db.init_app(app)
 
 

--- a/fourstoryFlask/routes.py
+++ b/fourstoryFlask/routes.py
@@ -1,13 +1,9 @@
 from datetime import datetime, timedelta
-from flask import Blueprint, redirect, render_template, request, session
-from dotenv import load_dotenv
+from flask import Blueprint, current_app, redirect, render_template, request, session
 import requests
-import os
 import urllib.parse
 
 from .models import find_user_by_token, save_user_token
-
-load_dotenv()
 
 bp = Blueprint('main', __name__)
 
@@ -15,7 +11,7 @@ bp = Blueprint('main', __name__)
 def index():
     # TODO: If the user is logged in, redirect them to the app
     vars = {
-        'FOURSQUARE_CLIENT_ID': os.getenv('FOURSQUARE_CLIENT_ID'),
+        'FOURSQUARE_CLIENT_ID': current_app.config.get('FOURSQUARE_CLIENT_ID'),
         'HOSTNAME': request.scheme+ "://" + request.host,
     }
     return render_template("index.html", **vars)
@@ -23,8 +19,8 @@ def index():
 # The route that foursquare directs users back to after they've logged in
 @bp.route('/auth')
 def authenticate():
-    FOURSQUARE_CLIENT_ID = os.getenv('FOURSQUARE_CLIENT_ID')
-    FOURSQUARE_CLIENT_SECRET = os.getenv('FOURSQUARE_CLIENT_SECRET')
+    FOURSQUARE_CLIENT_ID = current_app.config.get('FOURSQUARE_CLIENT_ID')
+    FOURSQUARE_CLIENT_SECRET = current_app.config.get('FOURSQUARE_CLIENT_SECRET')
 
     code = request.args.get('code')
 
@@ -59,8 +55,7 @@ def authenticate():
     return redirect(f'/history/date/{today}')
 
 @bp.route('/history/date/<date>')
-def history(date):
-    date_str = request.view_args['date']
+def history(date_str):
     date_obj = datetime.strptime(date_str, '%Y-%m-%d')
     after_timestamp = int(date_obj.timestamp())
     before_timestamp = after_timestamp + 86400


### PR DESCRIPTION
This centralizes configuration so all of the environment access is done
in the same place in run.py and the Blueprint can use flask.current_app
to access the config values. Moving the environment access out of the
Blueprint makes it easier to swap the source of the config e.g. to a
file or to something like Vault, and keeps the Blueprint reusable.
